### PR TITLE
Simplify compact view to be handled by CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,21 +45,19 @@
 			<p><br>Settings:</p>
 			<input type="checkbox" id="settings-compact-mode">
 			<script>
-				let settings_compact_mode = document.getElementById("settings-compact-mode")
-				settings_compact_mode.checked = localStorage.getItem("settings-compact-mode") === "true"
-				settings_compact_mode.addEventListener('change', function() {
-					localStorage.setItem("settings-compact-mode", this.checked)
-					let elements = document.getElementsByClassName("description")
-					if (this.checked) {
-						for (let element of elements) {
-							element.style.display = 'none'
-						}
+				const body = document.querySelector("body")
+				const settings_compact_mode = document.getElementById("settings-compact-mode")
+				const pick_compact = ({target: checkbox}) => {
+					localStorage.setItem("settings-compact-mode", checkbox.checked)
+					if (checkbox.checked) {
+						body.classList.add("compact")
 					} else {
-						for (let element of elements) {
-							element.style.display = 'inline'
-						}
+						body.classList.remove("compact")
 					}
-				});
+				}
+				settings_compact_mode.checked = localStorage.getItem("settings-compact-mode") === "true"
+				settings_compact_mode.addEventListener('change', pick_compact)
+				pick_compact({target: settings_compact_mode})
 			</script>
 			<label for="settings-compact-mode" class="unselectable">Compact mode</label>
 		</div>

--- a/pm.js
+++ b/pm.js
@@ -588,7 +588,6 @@ function CreateDiv(type, parent, text, name, description) {
 	element.appendChild(p)
 	element.appendChild(nname)
 	element.appendChild(ndescription)
-	if (document.getElementById("settings-compact-mode").checked) ndescription.style.display = 'none'
 	parent.appendChild(element)
 
 	return element

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,10 @@
 	display: inline-block;
 }
 
+.compact .description {
+	display: none;
+}
+
 .token a.description{
 	white-space: pre-wrap;
 }


### PR DESCRIPTION
Handling the compact view of the descriptions can be done in CSS instead, which makes it easier to handle as it only needs one class to be toggled in the DOM.