### PR TITLE
Change repeated IDs to classes

### DIFF
--- a/pm.js
+++ b/pm.js
@@ -583,8 +583,7 @@ function CreateDiv(type, parent, text, name, description) {
 	let ndescription = document.createElement("a")
 	ndescription.className = "description"
 	ndescription.appendChild(document.createTextNode(description))
-	element.className = "token"
-	element.id = type
+	element.classList.add("token", ...type.split(" "))
 	element.appendChild(p)
 	element.appendChild(nname)
 	element.appendChild(ndescription)
@@ -645,7 +644,7 @@ function PatternsShow(nodes, parent) {
 				case PAT.SETCHARS:
 					{
 						let len = node.text.length
-						let element = CreateDiv("char", parent, node.text, "Character.", (parent.id === "inverseset" ? "Doesn't match \"" : "Matches \"") + node.text + "\" literally.")
+						let element = CreateDiv("char", parent, node.text, "Character.", (parent.classList.contains("inverse") ? "Doesn't match \"" : "Matches \"") + node.text + "\" literally.")
 						PatternsShow(node.children, element)
 					}
 					break
@@ -692,7 +691,7 @@ function PatternsShow(nodes, parent) {
 					break
 				case PAT.INVERSESET:
 					{
-						let element = CreateDiv("inverseset", parent, "[^...]", "Inverse set.", "Matches any character except:")
+						let element = CreateDiv("inverse set", parent, "[^...]", "Inverse set.", "Matches any character except:")
 						PatternsShow(node.children, element)
 					}
 					break

--- a/styles.css
+++ b/styles.css
@@ -7,55 +7,55 @@
 	overflow-wrap: break-word;
 }
 
-#quantifier.token {
+.token.quantifier {
 	background: #6080ff;
 }
 
-#any.token {
+.token.any {
 	background: #CF7DE7;
 }
 
-#start.token, #end.token {
+.token.start, .token.end {
 	background: #FFD742;
 }
 
-#set.token {
+.token.set {
 	background: #d6dbec;
 }
 
-#inverseset.token {
+.token.inverseset {
 	background: #bcd7da;
 }
 
-#frontier.token {
+.token.frontier {
 	background: #9d97d4;
 }
 
-#balanced.token {
+.token.balanced {
 	background: #9f74f0;
 }
 
-#capture.token, #position.token {
+.token.capture, .token.position {
 	background: #a3ff8d;
 }
 
-#captureref.token {
+.token.captureref {
 	background: #d7ffcd;
 }
 
-#class.token {
+.token.class {
 	background: #A7D0E7;
 }
 
-#warning.token {
+.token.warning {
 	background: #fffc62;
 }
 
-#note.token {
+.token.note {
 	background: #62b3ff;
 }
 
-#error.token {
+.token.error {
 	background: #E76262;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -23,10 +23,6 @@
 	background: #d6dbec;
 }
 
-.token.inverseset {
-	background: #bcd7da;
-}
-
 .token.frontier {
 	background: #9d97d4;
 }


### PR DESCRIPTION
IDs should be unique within an HTML document, so they are poorly suited for marking the type of a subpattern.